### PR TITLE
7.10 安装基础工具-部分加上wireless_tools包

### DIFF
--- a/system-installation.md
+++ b/system-installation.md
@@ -221,11 +221,12 @@ $ grub-install --target=x86_64-efi --efi-directory=/boot   # 根据自己的系�
 ### 7.10 安装基础工具
 
 ```bash
-$ pacman -S zsh nano vim wpa_supplicant dhcpcd
+$ pacman -S zsh nano vim wpa_supplicant wireless_tools dhcpcd
 # zsh              shell
 # nano             编辑器
 # vim              编辑器
 # wpa_supplicant   上网工具
+# wireless_tools   无线上网工具
 # dhcpcd           动态分配IP地址工具
 ```
 


### PR DESCRIPTION
在「2.3 扫描当前设备下的WiFi列表并得到所有WiFi的名字」部分使用的iwlist命令在新安装好的 Arch Linux 是没有的……这个命令在wireless_tools包里面。没有这个命令可能会导致第一次启动系统的时候，没办法扫描无线网络（亲身经历的尴尬情况）

参考 https://bbs.archlinux.org/viewtopic.php?id=57201